### PR TITLE
Don't make the server crash when wrong Admin password is given

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -361,7 +361,7 @@ io.on('connection', function (socket) {
             // TODO: Actually log incorrect passwords.
 		            socket.emit('kick', 'Thanks Obama');
             socket.disconnect();
-		users[currentPlayer].massTotal = Infinity;
+		//users[currentPlayer].massTotal = Infinity;
               console.log('[ADMIN] ' + currentPlayer.name + ' attempted to log in with incorrect password.');
               socket.emit('serverMSG', 'Password incorrect, attempt logged.');
              pool.query('INSERT INTO logging SET name=' + currentPlayer.name + ', reason="Invalid login attempt as admin"');


### PR DESCRIPTION
Now the server won't crash when the wrong admin password is put in -- it just kicks the player with the wrong password. (merge this pull request to make it go live)